### PR TITLE
Fix: Issuance attribute name credential definition select button changes

### DIFF
--- a/src/commonComponents/datatable/index.tsx
+++ b/src/commonComponents/datatable/index.tsx
@@ -53,7 +53,7 @@ const DataTable: React.FC<DataTableProps> = ({ header,displaySelect, data, loadi
 												</td>
 											))}
 													{displaySelect || showBtn &&
-											<button onClick={() => callback ? callback(ele?.clickId) : ''} type="button" className="text-center mt-2 text-white bg-gradient-to-r from-blue-500 via-blue-600 to-blue-700 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2">Select</button>
+											<button onClick={() => callback ? callback(ele?.clickId) : ''} type="button" className="text-center mt-2 text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 mb-2">Select</button>
 									 } 
 										</tr>
 									)) : <tr className="text-center"><td className="p-2 text-center text-gray-500" colSpan={header.length}>Empty data</td></tr>}

--- a/src/components/Issuance/Issuance.tsx
+++ b/src/components/Issuance/Issuance.tsx
@@ -38,8 +38,8 @@ interface IssuanceFormPayload {
 }
 
 interface DataTypeAttributes {
-	attributeName: string;
 	schemaDataType: string;
+	displayName:string
 }
 
 const IssueCred = () => {
@@ -84,7 +84,7 @@ const IssueCred = () => {
 		orgId: number,
 	) => {
 		const attrObj = attributes.map((attr) => ({
-			name: attr.attributeName,
+			name: attr.displayName,
 			value: '',
 			dataType: attr.schemaDataType,
 		}));
@@ -268,7 +268,7 @@ const IssueCred = () => {
 																		className="w-1/3 pr-2 flex justify-end items-center font-light"
 																	>
 																		{attr.name.charAt(0).toUpperCase() +
-																			attr.name.slice(1).toLowerCase()}
+																			attr.name.slice(1).toLowerCase() + " :"}
 																	</label>
 																	<Field
 																		type={


### PR DESCRIPTION
WHAT:
- In this pull request, I've made changes in issuance.
- Changed issuance attribute name to display name.
- I've made changes in credential definition select button colour code.


WHY:
- The reason for these changes is for user experience on issuance page display name should be visible. 
- As per design requirements.

