### PR TITLE
fix: explore org button position and bug fixes

### DIFF
--- a/src/commonComponents/SchemaCard.tsx
+++ b/src/commonComponents/SchemaCard.tsx
@@ -2,7 +2,7 @@ import { Card } from 'flowbite-react';
 import { dateConversion } from '../utils/DateConversion';
 import DateTooltip from '../components/Tooltip';
 
-const SchemaCard = (props: {className:string, schemaName: string, version: string, schemaId: string, issuerDid: string, attributes: [], created: string, onClickCallback: (schemaId: string, attributes: string[], issuerDid:string, created:string) => void; }) => {
+const SchemaCard = (props: {className?:string, schemaName: string, version: string, schemaId: string, issuerDid: string, attributes: [], created: string, onClickCallback: (schemaId: string, attributes: string[], issuerDid:string, created:string) => void; }) => {
   return (
     <Card onClick={() => {
       props.onClickCallback(props.schemaId, props.attributes, props.issuerDid, props.created)

--- a/src/components/Profile/EditUserProfile.tsx
+++ b/src/components/Profile/EditUserProfile.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from "react";
 import type { UserProfile } from "./interfaces";
-import { getFromLocalStorage, getUserProfile, updateUserProfile } from "../../api/Auth";
-import { IMG_MAX_HEIGHT, IMG_MAX_WIDTH, apiStatusCodes, imageSizeAccepted, storageKeys } from "../../config/CommonConstant";
+import { setToLocalStorage, updateUserProfile } from "../../api/Auth";
+import { IMG_MAX_HEIGHT, IMG_MAX_WIDTH, imageSizeAccepted, storageKeys } from "../../config/CommonConstant";
 import type { AxiosResponse } from "axios";
 import CustomAvatar from '../Avatar'
 import { calculateSize, dataURItoBlob } from "../../utils/CompressImage";
-import { Avatar, Button, Label } from "flowbite-react";
+import { Button, Label } from "flowbite-react";
 import { Field, Form, Formik, FormikHelpers } from "formik";
-import { asset } from "../../lib/data";
 import * as yup from "yup"
 
 interface Values {
@@ -145,10 +144,6 @@ const UpdateUserProfile = ({ toggleEditProfile, userProfileInfo, updateProfile }
 
 
   const updateUserDetails = async (values: Values) => {
-
-    console.log(`Image::`, logoImage?.imagePreviewUrl);
-
-
     setLoading(true)
 
     const userData = {
@@ -162,9 +157,10 @@ const UpdateUserProfile = ({ toggleEditProfile, userProfileInfo, updateProfile }
     const resUpdateUserDetails = await updateUserProfile(userData)
 
     const { data } = resUpdateUserDetails as AxiosResponse
+		 setToLocalStorage(storageKeys.USER_PROFILE, userData)
 
     updateProfile(userData);
-
+		window.location.reload()
     setLoading(false)
 
   }
@@ -251,22 +247,24 @@ const UpdateUserProfile = ({ toggleEditProfile, userProfileInfo, updateProfile }
                   </div>
                   <button
                   type="button"
-                  className="absolute top-0 right-0  w-6 h-6 m-2 "
+                  className="absolute top-0 right-0 w-7 h-7 m-2 "
                   onClick={toggleEditProfile}
-                >
-                  <svg className="-top-1 -right-6 mr-1 w-6 h-6 mb-20"
-                    width="24" height="24"
-                    viewBox="0 0 24 24"
-                    stroke-width="2"
-                    stroke="currentColor"
-                    fill="none"
-                    stroke-linecap="round"
-                    stroke-linejoin="round">
-                    <path stroke="none" d="M0 0h24v24H0z" />
-                    <line x1="5" y1="12" x2="19" y2="12" />
-                    <line x1="5" y1="12" x2="11" y2="18" />
-                    <line x1="5" y1="12" x2="11" y2="6" />
-                  </svg>
+                >	
+								<svg
+								aria-hidden="true"
+								className="w-15 h-15"
+								fill="currentColor"
+								stroke-width="5"
+
+								viewBox="0 0 24 24"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									fillRule="evenodd"
+									d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+									clipRule="evenodd"
+								></path>
+							</svg>
 
                 </button>
 

--- a/src/components/Resources/Schema/SchemasList.tsx
+++ b/src/components/Resources/Schema/SchemasList.tsx
@@ -197,7 +197,7 @@ const SchemaList = (props: { schemaSelectionCallback: (schemaId: string, schemaD
 									schemaList.map((element, key) => (
 										<div className='p-2' key={key}>
 											<SchemaCard schemaName={element['name']} version={element['version']} schemaId={element['schemaLedgerId']} issuerDid={element['issuerId']} attributes={element['attributes']} created={element['createDateTime']}
-												onClickCallback={schemaSelectionCallback} />
+												onClickCallback={schemaSelectionCallback} className='' />
 										</div>
 									))}
 							</div>
@@ -217,7 +217,7 @@ const SchemaList = (props: { schemaSelectionCallback: (schemaId: string, schemaD
 						</div>) : (<EmptyListMessage
 							message={'No Schemas'}
 							description={'Get started by creating a new Schema'}
-							buttonContent={'Create'}
+							buttonContent={'Create Schema'}
 							svgComponent={<svg className='pr-2 mr-1' xmlns="http://www.w3.org/2000/svg" width="24" height="15" fill="none" viewBox="0 0 24 24">
 								<path fill="#fff" d="M21.89 9.89h-7.78V2.11a2.11 2.11 0 1 0-4.22 0v7.78H2.11a2.11 2.11 0 1 0 0 4.22h7.78v7.78a2.11 2.11 0 1 0 4.22 0v-7.78h7.78a2.11 2.11 0 1 0 0-4.22Z" />
 							</svg>}

--- a/src/components/Resources/Schema/SchemasList.tsx
+++ b/src/components/Resources/Schema/SchemasList.tsx
@@ -197,7 +197,7 @@ const SchemaList = (props: { schemaSelectionCallback: (schemaId: string, schemaD
 									schemaList.map((element, key) => (
 										<div className='p-2' key={key}>
 											<SchemaCard schemaName={element['name']} version={element['version']} schemaId={element['schemaLedgerId']} issuerDid={element['issuerId']} attributes={element['attributes']} created={element['createDateTime']}
-												onClickCallback={schemaSelectionCallback} className='' />
+												onClickCallback={schemaSelectionCallback} />
 										</div>
 									))}
 							</div>

--- a/src/components/organization/EditOrgdetailsModal.tsx
+++ b/src/components/organization/EditOrgdetailsModal.tsx
@@ -224,7 +224,7 @@ const EditOrgdetailsModal = (props: EditOrgdetailsModalProps) => {
                             description: yup
                                 .string()
                                 .min(2, 'Organization description must be at least 2 characters')
-                                .max(600, 'Organization description must be at most 600 characters')
+                                .max(255, 'Organization description must be at most 255 characters')
                                 .required('Description is required')
                         })}
                     validateOnBlur

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import { pathRoutes } from '../config/pathRoutes';
 				<div
 					class="flex flex-wrap justify-between items-center mx-auto max-w-screen-xl"
 				>
+				<div class="flex">
 					<a href="/" class="flex items-center">
 						<img
 							src="/images/CREDEBL_ICON.png"
@@ -23,12 +24,14 @@ import { pathRoutes } from '../config/pathRoutes';
 							CREDEBL</span
 						>
 					</a>
+					<a
+					href="/explore"
+					class="text-gray-600 py-2 bg-white hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 font-medium rounded-lg text-md px-4 lg:px-5 lg:py-2.5 ml-4 dark:bg-primary-600 dark:hover:bg-primary-700 focus:outline-none dark:focus:ring-primary-800"
+					>Explore Organizations</a
+				>
+				</div>				
 					<div class="flex items-center lg:order-2">
-						<a
-						href="/explore"
-						class="text-white bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:ring-primary-300 font-medium rounded-lg text-sm px-4 lg:px-5 py-2 lg:py-2.5 mr-4 dark:bg-primary-600 dark:hover:bg-primary-700 focus:outline-none dark:focus:ring-primary-800"
-						>Explore</a
-					>
+						
 						<a href="https://github.com/credebl" class="mr-3" target="_blank">
 							<svg
 								class="w-6 h-6 text-gray-800 dark:text-white"


### PR DESCRIPTION
## WHAT ##
Reset position of explore organisations on navbar as per new landing page design.
Changed edit user close svg from back arrow to close.
Bug: Close button redirects to users page instead of closing notification #134
Bug: Missing space between text and plus (+) icon on the schemas and create organization Page #131
Bug: Updated profile name not displayed on the profile's slider #124
Bug: The length of the description characters differ from the suggested length #138
Resolved type errors faced while working.
Removed commented and unused code.
