### PR TITLE
fix: Reject button issue on ecosystem invitations page

### DIFF
--- a/src/components/EcosystemInvite/EcoSystemReceivedInvitations.tsx
+++ b/src/components/EcosystemInvite/EcoSystemReceivedInvitations.tsx
@@ -309,6 +309,7 @@ const ReceivedInvitations = () => {
 																	'rejected',
 																)
 															}
+															disabled={!invitation?.orgData}
 															id={invitation.id}
 															color="bg-white"
 															className='mr-5 mt-5 text-base font-medium text-center text-gray-00 bg-secondary-700 hover:!bg-secondary-800 rounded-lg focus:ring-4 focus:ring-primary-300 sm:w-auto dark:bg-primary-600  dark:focus:ring-primary-800 dark:bg-gray-800"'


### PR DESCRIPTION
### What ###

- Resolved issue: Reject button enabled without selecting organization from select organization dropdown.

