### PR TITLE
fix: extra space between words

### DIFF
--- a/src/components/Profile/AddPasskey.tsx
+++ b/src/components/Profile/AddPasskey.tsx
@@ -223,7 +223,7 @@ const AddPasskey = ({ responseMessages }: { responseMessages: (value: IResponseM
 										<h1 className="text-gray-500 text-xl font-medium font-montserrat dark:text-white">
 											Add Passkey
 										</h1>
-										<p className="mt-2 text-gray-700 font-montserrat text-sm font-normal font-light leading-normal dark:text-white">
+										<p className="text-start mt-2 text-gray-700 font-montserrat text-sm font-normal font-light leading-normal dark:text-white">
 											With Passkey, no complex passwords to remember.
 										</p>
 									</div>

--- a/src/components/Profile/DisplayUserProfile.tsx
+++ b/src/components/Profile/DisplayUserProfile.tsx
@@ -15,7 +15,7 @@ const DisplayUserProfile = ({
 							<h1 className="text-gray-500 text-xl font-medium dark:text-white">
 								General
 							</h1>
-							<span className="flex flex-wrap text-gray-700 text-sm dark:text-white whitespace-normal	">
+							<span className="flex flex-wrap text-start text-gray-700 text-sm dark:text-white whitespace-normal">
 								Basic info, like your first name, last name and profile image
 								that will be displayed
 							</span>

--- a/src/components/Profile/EditUserProfile.tsx
+++ b/src/components/Profile/EditUserProfile.tsx
@@ -241,7 +241,7 @@ const EditUserProfile = ({ toggleEditProfile, userProfileInfo, updateProfile }: 
 
                         <div>
                           <h1 className="text-gray-500 text-xl font-medium font-montserrat dark:text-white">General</h1>
-                          <p className="mt-2 text-gray-700 font-montserrat text-sm font-normal font-light leading-normal dark:text-white">Basic info, like your first name, last name and profile image that will be displayed</p>
+                          <p className="text-start mt-2 text-gray-700 font-montserrat text-sm font-normal dark:text-white">Basic info, like your first name, last name and profile image that will be displayed</p>
                         </div>
 
                       </div>


### PR DESCRIPTION
## What

- Fixes extra space between two words for small screen

## How

- Override the default behavior