### PR TITLE
fix: user-profile payload

### DIFF
--- a/src/components/Authentication/SignInUserPasskey.tsx
+++ b/src/components/Authentication/SignInUserPasskey.tsx
@@ -70,8 +70,12 @@ const SignInUserPasskey = (signInUserProps: signInUserProps) => {
 				(element: { orgRole: { name: string } }) =>
 					permissionArray.push(element?.orgRole?.name),
 			);
+			const { id, profileImg, firstName, email, enableEcosystem, multiEcosystemSupport } = data?.data || {}
+			const userProfile = {
+				id, profileImg, firstName, email, enableEcosystem, multiEcosystemSupport
+			}
 			await setToLocalStorage(storageKeys.PERMISSIONS, permissionArray);
-			await setToLocalStorage(storageKeys.USER_PROFILE, data?.data);
+			await setToLocalStorage(storageKeys.USER_PROFILE, userProfile);
 			await setToLocalStorage(storageKeys.USER_EMAIL, data?.data?.email);
 			return {
 				role: role?.orgRole || ""

--- a/src/components/Authentication/SignInUserPassword.tsx
+++ b/src/components/Authentication/SignInUserPassword.tsx
@@ -56,7 +56,11 @@ const SignInUserPassword = (signInUserProps: SignInUser3Props) => {
 				(element: { orgRole: { name: string } }) =>
 					permissionArray.push(element?.orgRole?.name),
 			);
-			await setToLocalStorage(storageKeys.USER_PROFILE, data?.data);
+			const { id, profileImg, firstName, email, enableEcosystem, multiEcosystemSupport } = data?.data || {}
+			const userProfile = {
+				id, profileImg, firstName, email, enableEcosystem, multiEcosystemSupport
+			}
+			await setToLocalStorage(storageKeys.USER_PROFILE, userProfile);
 			await setToLocalStorage(storageKeys.USER_EMAIL, data?.data?.email);
 			return {
 				role: role?.orgRole ?? '',

--- a/src/components/Profile/UserProfile.tsx
+++ b/src/components/Profile/UserProfile.tsx
@@ -28,7 +28,11 @@ const UserProfile = ({ noBreadcrumb }: { noBreadcrumb?: boolean }) => {
 
       if (data?.statusCode === apiStatusCodes.API_STATUS_SUCCESS) {
         setPrePopulatedUserProfile(data?.data);
-        await setToLocalStorage(storageKeys.USER_PROFILE, data?.data)
+        const { id, profileImg, firstName, email, enableEcosystem, multiEcosystemSupport } = data?.data || {}
+        const userProfile = {
+          id, profileImg, firstName, email, enableEcosystem, multiEcosystemSupport
+        }
+        await setToLocalStorage(storageKeys.USER_PROFILE, userProfile)
         await setToLocalStorage(storageKeys.USER_EMAIL, data?.data?.email)
       }
     } catch (error) {


### PR DESCRIPTION
## What?
- Reduced user-profile payload to store in the `localStorage`
- Stored only below fields
    - id
    - profileImg
    - firstName
    - email
    - enableEcosystem
    - multiEcosystemSupport