### PR TITLE
fix: pagination parameter name to sync with backend

### DIFF
--- a/src/api/verification.ts
+++ b/src/api/verification.ts
@@ -47,7 +47,7 @@ export const getVerificationList = async ({
 	sortingOrder,
 }: IConnectionListAPIParameter) => {
 	const orgId = await getFromLocalStorage(storageKeys.ORG_ID);
-	const url = `${apiRoutes.organizations.root}/${orgId}${apiRoutes.Verification.verifyCredential}?pageSize=${itemPerPage}&pageNumber=${page}&searchByText=${search}&sortBy=${sortingOrder}&sortField=${sortBy}`;
+	const url = `${apiRoutes.organizations.root}/${orgId}${apiRoutes.Verification.verifyCredential}?pageSize=${itemPerPage}&pageNumber=${page}&search=${search}&sortBy=${sortingOrder}&sortField=${sortBy}`;
 
 	const axiosPayload = {
 		url,


### PR DESCRIPTION
## What

- Change variable for pagination in getting all verification list DTO from 'searchByText' to 'search'

## Why

- To maintain consistency for pagination