### PR TITLE
HotFix: Security error in console while downloading QR code in wallet details

### DIFF
--- a/src/app/LayoutCommon.astro
+++ b/src/app/LayoutCommon.astro
@@ -48,10 +48,6 @@ const refreshToken = getFromCookies(Astro.cookies, 'refresh');
 
 		<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
-			rel="stylesheet"
-		/>
 
 		<meta property="og:image" content={initData.PUBLIC_PLATFORM_LOGO} />
 		<script is:inline id="theme">


### PR DESCRIPTION
##WHAT
Removed duplicate Google API CDN.