### PR TITLE
fix: Double attributes displayed for a single schema during OOB and connection verification.

### DIFF
--- a/src/commonComponents/CustomCheckbox.tsx
+++ b/src/commonComponents/CustomCheckbox.tsx
@@ -3,13 +3,16 @@ import { setToLocalStorage } from '../api/Auth';
 import { storageKeys } from '../config/CommonConstant';
 import type { ICustomCheckboxProps, ISchemaData } from './interface';
 
-const CustomCheckbox: React.FC<ICustomCheckboxProps> = ({ showCheckbox, isVerificationUsingEmail, onChange, schemaData }) => {
+const CustomCheckbox: React.FC<ICustomCheckboxProps> = ({ showCheckbox, isSelectedSchema, isVerificationUsingEmail, onChange, schemaData }) => {
   const [checked, setChecked] = useState<boolean>(false);
   const handleCheckboxChange = async () => {
     const newChecked = !checked;
     setChecked(newChecked);
     onChange(newChecked, schemaData);
   };
+  useEffect(() => {
+    setChecked(isSelectedSchema);
+  }, [isSelectedSchema]);
 
   return (
     <>

--- a/src/commonComponents/SchemaCard.tsx
+++ b/src/commonComponents/SchemaCard.tsx
@@ -21,6 +21,10 @@ const SchemaCard = (props: ISchemaCardProps) => {
     orgDidDetails();
   }, []);
 
+  const isSelected = props.selectedSchemas?.some(
+    (selectedSchema) => selectedSchema.schemaId === props.schemaId || selectedSchema?.schemaLedgerId === props.schemaId
+  );
+
   const attributes = props.limitedAttributes !== false ? props?.attributes?.slice(0, 3) : props?.attributes
 
   const AttributesList: React.FC<{ attributes: IAttribute[], limitedAttributes?: boolean }> = ({ attributes, limitedAttributes }) => {
@@ -193,6 +197,7 @@ const SchemaData = {
 
        {props.showCheckbox && (
         <CustomCheckbox
+          isSelectedSchema={isSelected}
           onChange={handleCheckboxChange}
           showCheckbox={props.showCheckbox}
           schemaData={{ schemaId: props.schemaId, schemaName: props.schemaName, attributes: props.attributes }}

--- a/src/commonComponents/SchemaCard.tsx
+++ b/src/commonComponents/SchemaCard.tsx
@@ -22,7 +22,7 @@ const SchemaCard = (props: ISchemaCardProps) => {
   }, []);
 
   const isSelected = props.selectedSchemas?.some(
-    (selectedSchema) => selectedSchema.schemaId === props.schemaId || selectedSchema?.schemaLedgerId === props.schemaId
+    (selectedSchema) => selectedSchema.schemaId === props.schemaId || selectedSchema.schemaLedgerId === props.schemaId
   );
 
   const attributes = props.limitedAttributes !== false ? props?.attributes?.slice(0, 3) : props?.attributes

--- a/src/commonComponents/interface.ts
+++ b/src/commonComponents/interface.ts
@@ -1,3 +1,5 @@
+import type { ISchema } from "../components/Verification/interface";
+
 export interface IProps {
 	openModal: boolean;
 	closeModal: (flag: boolean) => void;
@@ -24,6 +26,7 @@ export interface ISchemaData {
 }
 
 export interface ICustomCheckboxProps {
+	isSelectedSchema: boolean;
 	showCheckbox: boolean;
 	isVerificationUsingEmail?: boolean;
 	onChange: (checked: boolean, schemaData?: ISchemaData) => void;
@@ -33,6 +36,7 @@ export interface ICustomCheckboxProps {
 export interface ISchemaCardProps {
 	className?: string;
 	schemaName: string;
+	selectedSchemas:ISchema[];
 	version: string;
 	schemaId: string;
 	issuerDid: string;

--- a/src/components/Resources/Schema/ViewSchema.tsx
+++ b/src/components/Resources/Schema/ViewSchema.tsx
@@ -132,11 +132,9 @@ const ViewSchemas = ({ schemaId }: { schemaId: string }) => {
 	const fetchData = async () => {
 		const organizationId = await getFromLocalStorage(storageKeys.ORG_ID);
 		setOrgId(String(organizationId));
-		const id = encodeURIComponent(schemaId);
-		if (id) {
-			await getSchemaDetails(id, String(organizationId));
-			await getCredentialDefinitionList(id, String(organizationId));
-		}
+			await getSchemaDetails(schemaId, String(organizationId));
+			await getCredentialDefinitionList(schemaId, String(organizationId));
+		
 	};
 
 	useEffect(() => {

--- a/src/components/Verification/VerificationSchemasList.tsx
+++ b/src/components/Verification/VerificationSchemasList.tsx
@@ -334,6 +334,7 @@ const [schemasList, setSchemasList] = useState([]);
 								schemasList.map((element) => (
 									<div className="px-0 sm:px-2" key={element['schemaLedgerId']}>
 										<SchemaCard
+										    selectedSchemas={selectedSchemas}
 											schemaName={element['name']}
 											version={element['version']}
 											schemaId={element['schemaLedgerId']}

--- a/src/components/Verification/interface.ts
+++ b/src/components/Verification/interface.ts
@@ -201,6 +201,7 @@ export interface ISchemaData {
 }
 
 export interface ISchema {
+    schemaLedgerId?: string;
     schemaId: string;
     attributes: IAttributesDetails[];
     issuerId: string;


### PR DESCRIPTION
### What

- fix: Double attributes displayed for a single schema during OOB and connection verification.
- fix: Schema Details Not Visible on "Schemas" Page When Creating Credential Definition.