### PR TITLE
Added Tooltip for dashboard titles ( organization , credential defination , schemas )

### DIFF
--- a/nextjs/src/features/dashboard/components/CredentialDefinition .tsx
+++ b/nextjs/src/features/dashboard/components/CredentialDefinition .tsx
@@ -9,9 +9,16 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import React, { useEffect, useState } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
+import { ToolTipDataForCredDef } from './TooltipData'
 import { getAllCredDef } from '@/app/api/schema'
 import { useAppSelector } from '@/lib/hooks'
 import { useRouter } from 'next/navigation'
@@ -63,7 +70,16 @@ const CredentialDefinition = (): React.JSX.Element => {
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <div className="space-y-1">
           <div className="flex items-center gap-x-2">
-            <CardTitle>Credential Definitions</CardTitle>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <CardTitle>Credential Definitions</CardTitle>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>
+                  <ToolTipDataForCredDef />
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <Badge>{credentialDefinition.length}</Badge>
           </div>
           <CardDescription>Manage your credential definitions</CardDescription>

--- a/nextjs/src/features/dashboard/components/OrganizationCardList.tsx
+++ b/nextjs/src/features/dashboard/components/OrganizationCardList.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useState } from 'react'
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 
@@ -23,6 +24,7 @@ import { Organisation } from '../type/organization'
 import { OrganizationRoles } from '@/common/enums'
 import { Plus } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
+import { ToolTipDataForOrganization } from './TooltipData'
 import { getOrganizations } from '@/app/api/organization'
 import { useRouter } from 'next/navigation'
 
@@ -103,7 +105,16 @@ const OrganizationCardList = (): React.JSX.Element => {
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <div className="space-y-1">
           <div className="flex items-center gap-x-2">
-            <CardTitle>Organizations</CardTitle>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <CardTitle>Organizations</CardTitle>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>
+                  <ToolTipDataForOrganization />
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <Badge>{orgList.length}</Badge>
           </div>
           <CardDescription>Manage your organizations</CardDescription>

--- a/nextjs/src/features/dashboard/components/SchemasList.tsx
+++ b/nextjs/src/features/dashboard/components/SchemasList.tsx
@@ -10,12 +10,19 @@ import {
 } from '@/components/ui/card'
 import { DidMethod, SchemaTypeValue } from '@/common/enums'
 import React, { useEffect, useState } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { Plus } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
+import { ToolTipDataForSchema } from './TooltipData'
 import { dateConversion } from '@/utils/DateConversion'
 import { getAllSchemasByOrgId } from '@/app/api/schema'
 import { useAppSelector } from '@/lib/hooks'
@@ -144,7 +151,16 @@ const SchemasList = (): React.JSX.Element => {
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <CardTitle className="text-xl">Schemas</CardTitle>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <CardTitle className="text-xl">Schemas</CardTitle>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>
+                  <ToolTipDataForSchema />
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <Badge>{schemas.length}</Badge>
           </div>
           <Button onClick={() => router.push('/organizations/schemas/create')}>

--- a/nextjs/src/features/dashboard/components/TooltipData.tsx
+++ b/nextjs/src/features/dashboard/components/TooltipData.tsx
@@ -1,0 +1,56 @@
+import { JSX } from 'react'
+
+export const ToolTipDataForOrganization = (): JSX.Element => (
+  <div className="text-left text-xs">
+    <p className="text-base">What is Organization?</p>
+    An organization is a participating entity, such as
+    <br />a business, institution, or group. Organizations
+    <br />
+    typically issue and verify some kind of digital
+    <br />
+    credentials, fostering trust within the digital
+    <br />
+    ecosystem.
+    <br />
+    Each organization is uniquely identified by a DID
+    <br />
+    (Decentralized Identifier), which is verifiable
+    <br />
+    publicly, thus enhancing the level of trust.
+  </div>
+)
+
+export const ToolTipDataForSchema = (): JSX.Element => (
+  <div className="text-left text-xs">
+    <p className="text-base">What is Schema?</p>
+    Schema is a machine-readable semantic
+    <br />
+    structure, a predefined data template
+    <br />
+    that provides a standard format for the
+    <br />
+    digital credential contents. Schemas
+    <br />
+    define attributes that are used in one
+    <br />
+    or more Credential Definitions.
+    <br />
+    Schemas are stored on the ledger.
+  </div>
+)
+
+export const ToolTipDataForCredDef = (): JSX.Element => (
+  <div className="text-left text-xs">
+    <p className="text-base">What is Credential Definition?</p>
+    A Credential Definition is a machine-readable
+    <br />
+    definition of any Schema or in simple terms,
+    <br />a tag created specific to an issuer and Schema.
+    <br />
+    Credentials are always issued by an issuer
+    <br />
+    using Cred-Def created by them.
+    <br />
+    Credential Definitions are stored on the ledger.
+  </div>
+)


### PR DESCRIPTION
# What 

- Added Tooltip for dashboard titles
![Screenshot from 2025-05-27 13-01-46](https://github.com/user-attachments/assets/12da9be3-01e2-46dc-b3f1-e3f40a254b8a)
![image](https://github.com/user-attachments/assets/4066fe47-f17b-4a70-9704-48f0ba2716c2)
![image](https://github.com/user-attachments/assets/de50f3ad-bf9c-4c7c-9522-bd6bad195451)
