### PR TITLE
Fixed issues related to loading and unnecessarily rendred components

### DIFF
--- a/nextjs/src/features/connections/components/Connections.tsx
+++ b/nextjs/src/features/connections/components/Connections.tsx
@@ -31,16 +31,7 @@ export default function Connections(): JSX.Element {
   const orgId = useAppSelector((state) => state.organization.orgId)
 
   const [isLoading, setIsLoading] = useState(false)
-  const [connectionData, setConnectionData] = useState<Connection[]>([
-    {
-      createDateTime: '',
-      createdBy: '',
-      orgId: '',
-      state: '',
-      theirLabel: '',
-      connectionId: '',
-    },
-  ])
+  const [connectionData, setConnectionData] = useState<Connection[]>([])
 
   const [paginationState, setPaginationState] = useState({
     pageIndex: 0,

--- a/nextjs/src/features/organization/components/OrganizationDashboard.tsx
+++ b/nextjs/src/features/organization/components/OrganizationDashboard.tsx
@@ -36,6 +36,7 @@ export const OrganizationDashboard = ({
   const [orgDashboard, setOrgDashboard] = useState<IOrgDashboard | null>(null)
   const [loading, setLoading] = useState(true)
   const [walletStatus, setWalletStatus] = useState<boolean>(false)
+	const [showSetupButton, setSetupButton] = useState<boolean>(false)
   const [, setError] = useState<string | null>(null)
 
   const selecteDropdownOrgId = useAppSelector(
@@ -60,7 +61,9 @@ export const OrganizationDashboard = ({
         data?.data?.org_agents[0]?.orgDid
       ) {
         setWalletStatus(true)
-      }
+      }else{
+				setSetupButton(true)
+			}
       setOrgData(data?.data)
     } else {
       setError(response as string)
@@ -273,6 +276,8 @@ export const OrganizationDashboard = ({
         ) : walletStatus === true ? (
           <OrganizationDetails orgData={orgData} />
         ) : (
+				<>
+				{showSetupButton &&
           <Button
             onClick={() =>
               router.push(
@@ -282,6 +287,8 @@ export const OrganizationDashboard = ({
           >
             Setup Your Wallet
           </Button>
+				}
+				</>
         )}
       </div>
     </PageContainer>

--- a/nextjs/src/features/organization/components/OrganizationDashboard.tsx
+++ b/nextjs/src/features/organization/components/OrganizationDashboard.tsx
@@ -36,7 +36,7 @@ export const OrganizationDashboard = ({
   const [orgDashboard, setOrgDashboard] = useState<IOrgDashboard | null>(null)
   const [loading, setLoading] = useState(true)
   const [walletStatus, setWalletStatus] = useState<boolean>(false)
-	const [showSetupButton, setSetupButton] = useState<boolean>(false)
+  const [showSetupButton, setSetupButton] = useState<boolean>(false)
   const [, setError] = useState<string | null>(null)
 
   const selecteDropdownOrgId = useAppSelector(
@@ -61,9 +61,9 @@ export const OrganizationDashboard = ({
         data?.data?.org_agents[0]?.orgDid
       ) {
         setWalletStatus(true)
-      }else{
-				setSetupButton(true)
-			}
+      } else {
+        setSetupButton(true)
+      }
       setOrgData(data?.data)
     } else {
       setError(response as string)
@@ -276,19 +276,19 @@ export const OrganizationDashboard = ({
         ) : walletStatus === true ? (
           <OrganizationDetails orgData={orgData} />
         ) : (
-				<>
-				{showSetupButton &&
-          <Button
-            onClick={() =>
-              router.push(
-                `/organizations/agent-config?orgId=${orgIdOfDashboard}`,
-              )
-            }
-          >
-            Setup Your Wallet
-          </Button>
-				}
-				</>
+          <>
+            {showSetupButton && (
+              <Button
+                onClick={() =>
+                  router.push(
+                    `/organizations/agent-config?orgId=${orgIdOfDashboard}`,
+                  )
+                }
+              >
+                Setup Your Wallet
+              </Button>
+            )}
+          </>
         )}
       </div>
     </PageContainer>

--- a/nextjs/src/features/organization/connectionIssuance/components/Credentials.tsx
+++ b/nextjs/src/features/organization/connectionIssuance/components/Credentials.tsx
@@ -121,6 +121,7 @@ const Credentials = (): JSX.Element => {
 
   useEffect(() => {
     if (!orgId) {
+			setLoading(false)
       return
     }
     getIssuedCredDefs()

--- a/nextjs/src/features/organization/connectionIssuance/components/Credentials.tsx
+++ b/nextjs/src/features/organization/connectionIssuance/components/Credentials.tsx
@@ -121,7 +121,7 @@ const Credentials = (): JSX.Element => {
 
   useEffect(() => {
     if (!orgId) {
-			setLoading(false)
+      setLoading(false)
       return
     }
     getIssuedCredDefs()

--- a/nextjs/src/features/profile/components/DevelopersSetting.tsx
+++ b/nextjs/src/features/profile/components/DevelopersSetting.tsx
@@ -56,7 +56,7 @@ const ClientCredentials = (): React.JSX.Element => {
   const [searchTerm] = useState('')
 
   const fetchOrganizations = async (): Promise<void> => {
-		setLoading(true)
+    setLoading(true)
     try {
       const response = await getOrganizations(
         currentPage,

--- a/nextjs/src/features/profile/components/DevelopersSetting.tsx
+++ b/nextjs/src/features/profile/components/DevelopersSetting.tsx
@@ -46,7 +46,7 @@ const ClientCredentials = (): React.JSX.Element => {
   const [buttonDisplay, setButtonDisplay] = useState<boolean>(true)
   const [regenerate, setRegenerate] = useState<boolean>(false)
 
-  const [hasOrganizations, setHasOrganizations] = useState<boolean>(false)
+  const [hasOrganizations, setHasOrganizations] = useState<boolean>(true)
   const token = useAppSelector((state) => state.auth.token)
   const orgId = useAppSelector((state) => state.organization.orgId)
   const [userRoles, setUserRoles] = useState<string[]>([])
@@ -56,6 +56,7 @@ const ClientCredentials = (): React.JSX.Element => {
   const [searchTerm] = useState('')
 
   const fetchOrganizations = async (): Promise<void> => {
+		setLoading(true)
     try {
       const response = await getOrganizations(
         currentPage,
@@ -179,7 +180,7 @@ const ClientCredentials = (): React.JSX.Element => {
 
   if (loading) {
     return (
-      <div className="flex h-full items-center justify-center">
+      <div className="flex h-lvh items-center justify-center">
         <Loader />
       </div>
     )
@@ -199,7 +200,7 @@ const ClientCredentials = (): React.JSX.Element => {
           />
         )}
         {!hasOrganizations ? (
-          <div className="flex h-full items-center justify-center">
+          <div className="flex h-[80vh] items-center justify-center">
             <div className="text-center">
               <div className="mb-4 text-2xl font-bold">No Organization</div>
               <p className="text-lg">

--- a/nextjs/src/features/profile/components/EditUserProfile.tsx
+++ b/nextjs/src/features/profile/components/EditUserProfile.tsx
@@ -213,7 +213,7 @@ export default function EditUserProfile({
                 <div className="flex flex-1 flex-col gap-4">
                   <div>
                     <label className="mb-2 block text-sm font-medium">
-                      First Name
+                      First Name{' '}<span className='text-destructive'>*</span>
                     </label>
                     <Field
                       as={Input}
@@ -226,15 +226,15 @@ export default function EditUserProfile({
                       className="w-3xl rounded-md p-2"
                     />
                     {formik.errors.firstName && formik.touched.firstName && (
-                      <div className="mt-1 text-sm">
-                        {formik.errors.firstName}
+                      <div className="mt-1 text-sm text-destructive">
+                        {formik.errors.firstName} 
                       </div>
                     )}
                   </div>
 
                   <div>
                     <label className="mb-2 block text-sm font-medium">
-                      Last Name
+                      Last Name{' '}<span className='text-destructive'>*</span>
                     </label>
                     <Field
                       as={Input}
@@ -246,8 +246,8 @@ export default function EditUserProfile({
                       className="w-3xl rounded-md p-2"
                     />
                     {formik.errors.lastName && formik.touched.lastName && (
-                      <div className="mt-1 text-sm">
-                        {formik.errors.lastName}
+                      <div className="mt-1 text-sm text-destructive">
+                        {formik.errors.lastName} 
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
# What 

* fixed Connections showing NA when no data
![image](https://github.com/user-attachments/assets/7ba67f8c-0d7d-49ab-b1eb-63bf5b28a5bd)
* fixed the  continous loader on issue page  when no organization.
![image](https://github.com/user-attachments/assets/d7aac8cd-b715-41a5-bcf0-a47d63b25028)
* fixed the no organization flash on visiting the page developer settings
* centered the no Organization msg and the loader for developer settings
[Screencast from 2025-06-16 16-18-16.webm](https://github.com/user-attachments/assets/cfff3689-7471-4122-ba44-32b6de5b30d9)
* profile edit page color and mandatory issue
![profile edit](https://github.com/user-attachments/assets/92fe9e9a-4016-44f1-9e10-26193d6df2b5)
* fixed the setup wallet button showing up while reloading org dashboard (rarely occuring)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes UI and state management issues across components to improve loading states, data display, and message centering.
> 
>   - **Behavior**:
>     - Fix `Connections.tsx` to not show 'N/A' when no data is available.
>     - Fix continuous loader issue in `Credentials.tsx` when no organization is present.
>     - Fix flash of 'No Organization' message in `DevelopersSetting.tsx`.
>     - Center 'No Organization' message and loader in `DevelopersSetting.tsx`.
>     - Fix `EditUserProfile.tsx` to correctly display mandatory field indicators.
>     - Fix `OrganizationDashboard.tsx` to conditionally show 'Setup Your Wallet' button only when necessary.
>   - **UI Adjustments**:
>     - Center 'No Organization' message and loader in `DevelopersSetting.tsx`.
>     - Update `EditUserProfile.tsx` to use `text-destructive` class for mandatory field indicators.
>   - **State Management**:
>     - Initialize `connectionData` as an empty array in `Connections.tsx`.
>     - Add `showSetupButton` state in `OrganizationDashboard.tsx` to manage wallet setup button visibility.
>     - Set `loading` to false in `Credentials.tsx` when no organization is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 1e7b5f0255b44f327494c820d37c5e054f0da581. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->