### PR TITLE
Fix/issues for passkey flow

### DIFF
--- a/nextjs/src/features/passkey/PassKeyAddDevice.tsx
+++ b/nextjs/src/features/passkey/PassKeyAddDevice.tsx
@@ -15,11 +15,9 @@ import { Field, Form, Formik } from 'formik'
 import { AxiosResponse } from 'axios'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { RootState } from '@/lib/store'
 import { addPasskeyUserDetails } from '@/app/api/Fido'
 import { apiStatusCodes } from '@/config/CommonConstant'
 import { passwordEncryption } from '@/app/api/Auth'
-import { useSelector } from 'react-redux'
 import { useState } from 'react'
 
 interface PasswordValue {
@@ -31,10 +29,12 @@ interface PasskeyAddDeviceProps {
   setOpenModel: (flag: boolean) => void
   closeModal: (flag: boolean) => void
   registerWithPasskey: (flag: boolean) => Promise<void>
+  email: string | undefined
 }
 
 export default function PasskeyAddDevice({
   openModal,
+  email,
   setOpenModel,
   registerWithPasskey,
 }: PasskeyAddDeviceProps): React.JSX.Element {
@@ -43,7 +43,7 @@ export default function PasskeyAddDevice({
   const [nextStep, setNextStep] = useState(false)
   const [passwordVisible, setPasswordVisible] = useState(false)
 
-  const userEmail = useSelector((state: RootState) => state.profile.email)
+  const userEmail = email
   const savePassword = async (values: PasswordValue): Promise<void> => {
     try {
       const payload = {


### PR DESCRIPTION
Fix/issues for passkey flow
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `PasskeyAddDevice` now uses an `email` prop instead of `useSelector` for user email.
> 
>   - **Behavior**:
>     - `PasskeyAddDevice` now uses `email` prop instead of `useSelector` to get user email.
>   - **Props**:
>     - Added `email` prop to `PasskeyAddDeviceProps` interface.
>   - **Code Simplification**:
>     - Removed `useSelector` import and usage in `PasskeyAddDevice.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 7a53b185648670fb97ccc3184f41144299c1ddda. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->