### PR TITLE
fix: sign up with passkey

### DIFF
--- a/nextjs/src/features/components/UserInfoForm.tsx
+++ b/nextjs/src/features/components/UserInfoForm.tsx
@@ -25,6 +25,7 @@ import { AlertComponent } from '@/components/AlertComponent'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { startRegistration } from '@simplewebauthn/browser'
+import { v4 as uuidv4 } from 'uuid'
 
 interface StepUserInfoProps {
   email: string
@@ -38,6 +39,13 @@ export interface RegistrationOptionInterface {
 
 export enum Devices {
   Linux = 'linux',
+}
+export interface AddPasswordDetails {
+  email: string
+  password: string
+  isPasskey: boolean
+  firstName: string | null
+  lastName: string | null
 }
 
 const validationSchema = Yup.object().shape({
@@ -86,6 +94,8 @@ export default function UserInfoForm({
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [success, setSuccess] = useState<string | null>(null)
   const [failure, setFailure] = useState<string | null>(null)
+  const [passkeyFirstName, setPasskeyFirstName] = useState('')
+  const [passkeyLastName, setPasskeyLastName] = useState('')
 
   const searchParams = useSearchParams()
   const redirectTo = searchParams.get('redirectTo')
@@ -134,6 +144,37 @@ export default function UserInfoForm({
     }
   }
 
+  const passkeySubmit = async (values: {
+    firstName: string
+    lastName: string
+  }): Promise<void> => {
+    const password: string = uuidv4()
+    const payload: AddPasswordDetails = {
+      email,
+      isPasskey: true,
+      firstName: values.firstName,
+      lastName: values.lastName,
+      password: passwordEncryption(password),
+    }
+
+    setLoading(true)
+    try {
+      const userRsp = await addPasswordDetails(payload)
+      const { data } = userRsp as AxiosResponse
+
+      if (data?.statusCode === apiStatusCodes.API_STATUS_CREATED) {
+        window.location.href =
+          '/sign-in?signup=true&fidoFlag=true&method=passkey'
+      } else {
+        setErrMsg(data?.message || 'Passkey registration failed')
+      }
+    } catch (error) {
+      setErrMsg('Error during passkey registration')
+    } finally {
+      setLoading(false)
+    }
+  }
+
   const showFidoError = (error: unknown): void => {
     const err = error as AxiosError
     if (
@@ -153,7 +194,10 @@ export default function UserInfoForm({
       const deviceDetailsResp = await addDeviceDetails(deviceBody)
       const { data } = deviceDetailsResp as AxiosResponse
       if (data?.statusCode === apiStatusCodes.API_STATUS_SUCCESS) {
-        router.push('/sign-in')
+        passkeySubmit({
+          firstName: passkeyFirstName,
+          lastName: passkeyLastName,
+        })
       }
       setTimeout(() => {
         setAddSuccess('')
@@ -317,7 +361,10 @@ export default function UserInfoForm({
                 placeholder="First name"
                 name="firstName"
                 value={values.firstName}
-                onChange={handleChange}
+                onChange={(e) => {
+                  handleChange(e)
+                  setPasskeyFirstName(e.target.value)
+                }}
                 onBlur={handleBlur}
                 className="bg-[var(--color-bg-primary)] text-[var(--color-text-primary)]"
               />
@@ -332,7 +379,10 @@ export default function UserInfoForm({
                 placeholder="Last name"
                 name="lastName"
                 value={values.lastName}
-                onChange={handleChange}
+                onChange={(e) => {
+                  handleChange(e)
+                  setPasskeyLastName(e.target.value)
+                }}
                 onBlur={handleBlur}
                 className="bg-[var(--color-bg-primary)] text-[var(--color-text-primary)]"
               />

--- a/nextjs/src/features/components/UserInfoForm.tsx
+++ b/nextjs/src/features/components/UserInfoForm.tsx
@@ -86,7 +86,6 @@ export default function UserInfoForm({
   const [, setDisableFlag] = useState<boolean>(false)
   const [, setAddFailure] = useState<string | null>(null)
   const [, setAddSuccess] = useState<string | null>(null)
-  const [, setErrMsg] = useState<string | null>(null)
   const router = useRouter()
   const [, setFidoLoader] = useState<boolean>(false)
   const [, setFidoError] = useState('')
@@ -166,10 +165,10 @@ export default function UserInfoForm({
         window.location.href =
           '/sign-in?signup=true&fidoFlag=true&method=passkey'
       } else {
-        setErrMsg(data?.message || 'Passkey registration failed')
+        setFailure(data?.message || 'Passkey registration failed')
       }
     } catch (error) {
-      setErrMsg('Error during passkey registration')
+      setFailure('Error during passkey registration')
     } finally {
       setLoading(false)
     }
@@ -274,7 +273,7 @@ export default function UserInfoForm({
 
         await verifyRegistrationMethod(verifyRegistrationObj, email)
       } else {
-        setErrMsg(
+        setFailure(
           (generateRegistrationResponse as AxiosResponse)?.data?.message ||
             'An error occurred',
         )


### PR DESCRIPTION
### What

- fix: sign up with passkey
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds passkey registration support in `UserInfoForm.tsx`, including new `passkeySubmit` function and state management updates.
> 
>   - **Behavior**:
>     - Adds `passkeySubmit` function in `UserInfoForm.tsx` to handle passkey registration, generating a UUID as a password.
>     - Modifies `addDeviceDetailsMethod` to call `passkeySubmit` upon successful device addition.
>     - Updates `registerWithPasskey` to initiate passkey registration process.
>   - **State Management**:
>     - Introduces `passkeyFirstName` and `passkeyLastName` state variables to store user input during passkey registration.
>     - Removes unused `setErrMsg` state.
>   - **Error Handling**:
>     - Updates error handling in `verifyRegistrationMethod` and `showFidoError` to improve feedback during registration failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 7174732555a10d70e9f2e012fbc23de47dcdddcf. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->