### PR TITLE
Fixed color for side bar and removed user option from sidebar

### DIFF
--- a/nextjs/src/components/layout/app-sidebar.tsx
+++ b/nextjs/src/components/layout/app-sidebar.tsx
@@ -166,6 +166,7 @@ export default function AppSidebar(): React.JSX.Element {
                       <SidebarMenuButton
                         tooltip={item.title}
                         isActive={pathname === item.url}
+                        className="data-[active=true]:bg-primary data-[active=true]:hover:bg-primary/90 data-[active=true]:text-primary-foreground"
                       >
                         {item.icon && <Icon />}
                         <span>{item.title}</span>
@@ -180,6 +181,7 @@ export default function AppSidebar(): React.JSX.Element {
                             <SidebarMenuSubButton
                               asChild
                               isActive={pathname === subItem.url}
+                              className="data-[active=true]:bg-primary data-[active=true]:hover:bg-primary/90 data-[active=true]:text-primary-foreground"
                             >
                               <Link href={subItem.url}>
                                 <span>{subItem.title}</span>
@@ -197,6 +199,7 @@ export default function AppSidebar(): React.JSX.Element {
                     asChild
                     tooltip={item.title}
                     isActive={pathname === item.url}
+                    className="data-[active=true]:bg-primary data-[active=true]:hover:bg-primary/90 data-[active=true]:text-primary-foreground"
                   >
                     <Link href={item.url}>
                       <Icon />

--- a/nextjs/src/constants/data.ts
+++ b/nextjs/src/constants/data.ts
@@ -30,14 +30,6 @@ export const navItems: NavItem[] = [
     items: [], // No child items
   },
   {
-    title: 'Users',
-    url: '/users',
-    icon: 'user',
-    shortcut: ['k', 'k'],
-    isActive: false,
-    items: [], // No child items
-  },
-  {
     title: 'Connections',
     url: '/connections',
     icon: 'connections',


### PR DESCRIPTION
# What

Side bar color as per tweak cn and removed user option
![image](https://github.com/user-attachments/assets/0ba8e61a-716b-47bc-bcc1-f6232a2b1352)
![image](https://github.com/user-attachments/assets/4add691d-1d62-4eaa-ae8e-72f48dfa99ca)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated sidebar color scheme and removed 'Users' option from navigation.
> 
>   - **UI Changes**:
>     - Updated sidebar button styles in `app-sidebar.tsx` to use `bg-primary` and `text-primary-foreground` for active items.
>   - **Navigation**:
>     - Removed 'Users' option from `navItems` in `data.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 1fded30ddb0d14a957db8fe987dbce8706d6b1db. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->