### PR TITLE
Replaced breadcrumb id's with their relevant name for better UX

### DIFF
--- a/nextjs/src/components/breadcrumbs.tsx
+++ b/nextjs/src/components/breadcrumbs.tsx
@@ -8,13 +8,28 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
-import React, { Fragment } from 'react'
+import React, { Fragment, useMemo } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
 
 import { IconSlash } from '@tabler/icons-react'
 import { useBreadcrumbs } from '@/hooks/use-breadcrumbs'
 
 export function Breadcrumbs(): React.JSX.Element | null {
   const items = useBreadcrumbs()
+  const [copied, setCopied] = React.useState(false)
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const alias = React.useMemo(() => searchParams.get('alias'), [searchParams])
+  const UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  const isOrganizationUUIDPath = useMemo(() => {
+    const parts = pathname.split('/').filter(Boolean) // remove empty strings
+    return (
+      parts.length === 2 &&
+      parts[0] === 'organizations' &&
+      UUID_REGEX.test(parts[1])
+    )
+  }, [pathname])
 
   if (items.length === 0) {
     return null
@@ -23,29 +38,62 @@ export function Breadcrumbs(): React.JSX.Element | null {
   return (
     <Breadcrumb>
       <BreadcrumbList>
-        {items.map((item, index) => {
-          const decodedTitle = decodeURIComponent(item.title)
+        {isOrganizationUUIDPath ? (
+          <>
+            <BreadcrumbItem className="hidden md:block">
+              <BreadcrumbLink
+                onClick={() => {
+                  window.navigator.clipboard.writeText(items[1].title)
+                  setCopied(true)
+                  setTimeout(() => {
+                    setCopied(false)
+                  }, 2000)
+                }}
+              >
+                <div className="relative">
+                  Overview
+                  {copied && (
+                    <div className="absolute top-7 z-50 ml-2 rounded-md bg-black px-2 py-1 text-xs font-semibold text-white">
+                      Copied!
+                    </div>
+                  )}
+                </div>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          </>
+        ) : (
+          <>
+            {items.map((item, index) => {
+              const decodedTitle = decodeURIComponent(item.title)
 
-          return (
-            <Fragment key={item.link ? item.link : `${item.title}-${index}`}>
-              {index !== items.length - 1 && (
-                <BreadcrumbItem className="hidden md:block">
-                  <BreadcrumbLink href={item.link || `/schemas/${item.title}`}>
-                    {decodedTitle}
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-              )}
-              {index < items.length - 1 && (
-                <BreadcrumbSeparator className="hidden md:block">
-                  <IconSlash />
-                </BreadcrumbSeparator>
-              )}
-              {index === items.length - 1 && (
-                <BreadcrumbPage>{decodedTitle}</BreadcrumbPage>
-              )}
-            </Fragment>
-          )
-        })}
+              return (
+                <Fragment
+                  key={item.link ? item.link : `${item.title}-${index}`}
+                >
+                  {index !== items.length - 1 && (
+                    <BreadcrumbItem className="hidden md:block">
+                      <BreadcrumbLink
+                        href={item.link || `/schemas/${item.title}`}
+                      >
+                        {decodedTitle}
+                      </BreadcrumbLink>
+                    </BreadcrumbItem>
+                  )}
+                  {index < items.length - 1 && (
+                    <BreadcrumbSeparator className="hidden md:block">
+                      <IconSlash />
+                    </BreadcrumbSeparator>
+                  )}
+                  {index === items.length - 1 && (
+                    <BreadcrumbPage>
+                      {alias ? alias : decodedTitle}
+                    </BreadcrumbPage>
+                  )}
+                </Fragment>
+              )
+            })}
+          </>
+        )}
       </BreadcrumbList>
     </Breadcrumb>
   )

--- a/nextjs/src/components/breadcrumbs.tsx
+++ b/nextjs/src/components/breadcrumbs.tsx
@@ -12,6 +12,7 @@ import React, { Fragment, useMemo } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation'
 
 import { IconSlash } from '@tabler/icons-react'
+import { UUID_REGEX } from '@/config/CommonConstant'
 import { useBreadcrumbs } from '@/hooks/use-breadcrumbs'
 
 export function Breadcrumbs(): React.JSX.Element | null {
@@ -20,8 +21,6 @@ export function Breadcrumbs(): React.JSX.Element | null {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const alias = React.useMemo(() => searchParams.get('alias'), [searchParams])
-  const UUID_REGEX =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
   const isOrganizationUUIDPath = useMemo(() => {
     const parts = pathname.split('/').filter(Boolean) // remove empty strings
     return (
@@ -35,21 +34,21 @@ export function Breadcrumbs(): React.JSX.Element | null {
     return null
   }
 
+  function copyToClipboard(text: string): void {
+    window.navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => {
+      setCopied(false)
+    }, 2000)
+  }
+
   return (
     <Breadcrumb>
       <BreadcrumbList>
         {isOrganizationUUIDPath ? (
           <>
             <BreadcrumbItem className="hidden md:block">
-              <BreadcrumbLink
-                onClick={() => {
-                  window.navigator.clipboard.writeText(items[1].title)
-                  setCopied(true)
-                  setTimeout(() => {
-                    setCopied(false)
-                  }, 2000)
-                }}
-              >
+              <BreadcrumbLink onClick={() => copyToClipboard(items[1].title)}>
                 <div className="relative">
                   Overview
                   {copied && (
@@ -86,7 +85,21 @@ export function Breadcrumbs(): React.JSX.Element | null {
                   )}
                   {index === items.length - 1 && (
                     <BreadcrumbPage>
-                      {alias ? alias : decodedTitle}
+                      {alias ? (
+                        <button
+                          className="relative"
+                          onClick={() => copyToClipboard(decodedTitle)}
+                        >
+                          {alias}
+                          {copied && (
+                            <div className="absolute top-7 z-50 ml-2 rounded-md bg-black px-2 py-1 text-xs font-semibold text-white">
+                              Copied!
+                            </div>
+                          )}
+                        </button>
+                      ) : (
+                        decodedTitle
+                      )}
                     </BreadcrumbPage>
                   )}
                 </Fragment>

--- a/nextjs/src/config/CommonConstant.ts
+++ b/nextjs/src/config/CommonConstant.ts
@@ -19,6 +19,8 @@ export const totalRecords = 'totalRecords'
 export const successfulRecords = 'successfulRecords'
 export const currentPageNumber = 1
 export const polygonFaucet = 'https://faucet.polygon.technology/'
+export const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export const apiStatusCodes = {
   API_STATUS_SUCCESS: 200,

--- a/nextjs/src/features/organization/components/OrganizationDashboard.tsx
+++ b/nextjs/src/features/organization/components/OrganizationDashboard.tsx
@@ -60,7 +60,6 @@ export const OrganizationDashboard = ({
       return
     }
 
-    // setLoading(true)
     const useOrgId = activeOrgId === orgIdOfDashboard ? orgId : activeOrgId
     const response = await getOrganizationById(useOrgId as string)
     const { data } = response as AxiosResponse
@@ -81,11 +80,9 @@ export const OrganizationDashboard = ({
     } else {
       setError(response as string)
     }
-    // setLoading(false)
   }
 
   const fetchOrganizationDashboardDetails = async (): Promise<void> => {
-    // setLoading(true)
     if (orgId) {
       const response = await getOrgDashboard(orgIdOfDashboard as string)
       const { data } = response as AxiosResponse
@@ -96,7 +93,6 @@ export const OrganizationDashboard = ({
         setError(response as string)
       }
     }
-    // setLoading(false)
   }
 
   const handleEditOrg = (): void => {

--- a/nextjs/src/features/organization/components/OrganizationDashboard.tsx
+++ b/nextjs/src/features/organization/components/OrganizationDashboard.tsx
@@ -3,7 +3,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Card, CardContent } from '@/components/ui/card'
 import { IOrgDashboard, IOrganisation } from './interfaces/organization'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useTransition } from 'react'
 import {
   Tooltip,
   TooltipContent,
@@ -39,6 +39,7 @@ export const OrganizationDashboard = ({
   const [showSetupButton, setSetupButton] = useState<boolean>(false)
   const [, setError] = useState<string | null>(null)
   const [isWalletSetupLoading, setIsWalletSetupLoading] = useState(false)
+  const [isPending, startTransition] = useTransition()
 
   const selecteDropdownOrgId = useAppSelector(
     (state) => state.organization.orgId,
@@ -59,12 +60,11 @@ export const OrganizationDashboard = ({
       return
     }
 
-    setLoading(true)
+    // setLoading(true)
     const useOrgId = activeOrgId === orgIdOfDashboard ? orgId : activeOrgId
     const response = await getOrganizationById(useOrgId as string)
     const { data } = response as AxiosResponse
 
-    setLoading(false)
     if (data?.statusCode === apiStatusCodes.API_STATUS_SUCCESS) {
       if (
         data?.data?.org_agents?.length > 0 &&
@@ -75,18 +75,20 @@ export const OrganizationDashboard = ({
         setSetupButton(true)
       }
       setOrgData(data?.data)
+      startTransition(() => {
+        router.push(`/organizations/${useOrgId}`)
+      })
     } else {
       setError(response as string)
     }
-    setLoading(false)
+    // setLoading(false)
   }
 
   const fetchOrganizationDashboardDetails = async (): Promise<void> => {
-    setLoading(true)
+    // setLoading(true)
     if (orgId) {
       const response = await getOrgDashboard(orgIdOfDashboard as string)
       const { data } = response as AxiosResponse
-      setLoading(false)
 
       if (data?.statusCode === apiStatusCodes.API_STATUS_SUCCESS) {
         setOrgDashboard(data?.data)
@@ -94,7 +96,7 @@ export const OrganizationDashboard = ({
         setError(response as string)
       }
     }
-    setLoading(false)
+    // setLoading(false)
   }
 
   const handleEditOrg = (): void => {
@@ -106,9 +108,18 @@ export const OrganizationDashboard = ({
   }
 
   useEffect(() => {
-    fetchOrganizationDetails()
-    fetchOrganizationDashboardDetails()
+    async function loadData(): Promise<void> {
+      setLoading(true)
+      await fetchOrganizationDetails()
+      await fetchOrganizationDashboardDetails()
+      setLoading(false)
+    }
+    loadData()
   }, [activeOrgId])
+
+  if (isPending || loading) {
+    return <Loader />
+  }
 
   return (
     <PageContainer>

--- a/nextjs/src/features/schemas/components/SchemaCard.tsx
+++ b/nextjs/src/features/schemas/components/SchemaCard.tsx
@@ -108,7 +108,9 @@ const SchemaCard = (props: ISchemaCardProps): React.JSX.Element => {
     }
 
     if (!props.w3cSchema && !hasNestedAttributes && props.schemaId) {
-      router.push(`/organizations/schemas/${props.schemaId}`)
+      router.push(
+        `/organizations/schemas/${props.schemaId}?alias=${props.schemaName}`,
+      )
     }
 
     if (props.onClickCallback) {


### PR DESCRIPTION
# What 

Changed the bread crumb id's to its relevant name
<img width="1916" height="498" alt="image" src="https://github.com/user-attachments/assets/61326598-2f02-4ec3-92be-f102eea7715a" />
changed it as discussed in meeting to replace organization with overview
<img width="1916" height="498" alt="image" src="https://github.com/user-attachments/assets/869065b0-32f3-40d8-bb80-ee24fcde1ca3" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaced breadcrumb IDs with names, added copy functionality, and improved navigation in `OrganizationDashboard` and `SchemaCard`.
> 
>   - **Breadcrumbs**:
>     - Replace breadcrumb IDs with relevant names in `breadcrumbs.tsx`.
>     - Add copy-to-clipboard functionality for breadcrumb names.
>     - Use `UUID_REGEX` to identify organization UUID paths.
>   - **OrganizationDashboard**:
>     - Use `useTransition` for smoother navigation in `OrganizationDashboard.tsx`.
>     - Refactor loading logic to use `useEffect` and `useTransition`.
>   - **SchemaCard**:
>     - Append `alias` query parameter to schema URL in `SchemaCard.tsx`.
>   - **Constants**:
>     - Add `UUID_REGEX` to `CommonConstant.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 87742439e1c84ad187e0ec697af683e6290f3da7. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->