### PR TITLE
 Replaced breadcrumb id's with their relevant name for better UX 

### DIFF
--- a/nextjs/src/components/breadcrumbs.tsx
+++ b/nextjs/src/components/breadcrumbs.tsx
@@ -8,44 +8,105 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
-import React, { Fragment } from 'react'
+import React, { Fragment, useMemo } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
 
 import { IconSlash } from '@tabler/icons-react'
+import { UUID_REGEX } from '@/config/CommonConstant'
 import { useBreadcrumbs } from '@/hooks/use-breadcrumbs'
 
 export function Breadcrumbs(): React.JSX.Element | null {
   const items = useBreadcrumbs()
+  const [copied, setCopied] = React.useState(false)
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const alias = React.useMemo(() => searchParams.get('alias'), [searchParams])
+  const isOrganizationUUIDPath = useMemo(() => {
+    const parts = pathname.split('/').filter(Boolean) // remove empty strings
+    return (
+      parts.length === 2 &&
+      parts[0] === 'organizations' &&
+      UUID_REGEX.test(parts[1])
+    )
+  }, [pathname])
 
   if (items.length === 0) {
     return null
   }
 
+  function copyToClipboard(text: string): void {
+    window.navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => {
+      setCopied(false)
+    }, 2000)
+  }
+
   return (
     <Breadcrumb>
       <BreadcrumbList>
-        {items.map((item, index) => {
-          const decodedTitle = decodeURIComponent(item.title)
+        {isOrganizationUUIDPath ? (
+          <>
+            <BreadcrumbItem className="hidden md:block">
+              <BreadcrumbLink onClick={() => copyToClipboard(items[1].title)}>
+                <div className="relative">
+                  Overview
+                  {copied && (
+                    <div className="absolute top-7 z-50 ml-2 rounded-md bg-black px-2 py-1 text-xs font-semibold text-white">
+                      Copied!
+                    </div>
+                  )}
+                </div>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          </>
+        ) : (
+          <>
+            {items.map((item, index) => {
+              const decodedTitle = decodeURIComponent(item.title)
 
-          return (
-            <Fragment key={item.link ? item.link : `${item.title}-${index}`}>
-              {index !== items.length - 1 && (
-                <BreadcrumbItem className="hidden md:block">
-                  <BreadcrumbLink href={item.link || `/schemas/${item.title}`}>
-                    {decodedTitle}
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-              )}
-              {index < items.length - 1 && (
-                <BreadcrumbSeparator className="hidden md:block">
-                  <IconSlash />
-                </BreadcrumbSeparator>
-              )}
-              {index === items.length - 1 && (
-                <BreadcrumbPage>{decodedTitle}</BreadcrumbPage>
-              )}
-            </Fragment>
-          )
-        })}
+              return (
+                <Fragment
+                  key={item.link ? item.link : `${item.title}-${index}`}
+                >
+                  {index !== items.length - 1 && (
+                    <BreadcrumbItem className="hidden md:block">
+                      <BreadcrumbLink
+                        href={item.link || `/schemas/${item.title}`}
+                      >
+                        {decodedTitle}
+                      </BreadcrumbLink>
+                    </BreadcrumbItem>
+                  )}
+                  {index < items.length - 1 && (
+                    <BreadcrumbSeparator className="hidden md:block">
+                      <IconSlash />
+                    </BreadcrumbSeparator>
+                  )}
+                  {index === items.length - 1 && (
+                    <BreadcrumbPage>
+                      {alias ? (
+                        <button
+                          className="relative"
+                          onClick={() => copyToClipboard(decodedTitle)}
+                        >
+                          {alias}
+                          {copied && (
+                            <div className="absolute top-7 z-50 ml-2 rounded-md bg-black px-2 py-1 text-xs font-semibold text-white">
+                              Copied!
+                            </div>
+                          )}
+                        </button>
+                      ) : (
+                        decodedTitle
+                      )}
+                    </BreadcrumbPage>
+                  )}
+                </Fragment>
+              )
+            })}
+          </>
+        )}
       </BreadcrumbList>
     </Breadcrumb>
   )

--- a/nextjs/src/components/breadcrumbs.tsx
+++ b/nextjs/src/components/breadcrumbs.tsx
@@ -35,7 +35,9 @@ export function Breadcrumbs(): React.JSX.Element | null {
   }
 
   function copyToClipboard(text: string): void {
-    window.navigator.clipboard.writeText(text)
+    navigator.clipboard.writeText(text).catch((err) => {
+      console.error('Failed to copy text: ', err)
+    })
     setCopied(true)
     setTimeout(() => {
       setCopied(false)

--- a/nextjs/src/config/CommonConstant.ts
+++ b/nextjs/src/config/CommonConstant.ts
@@ -19,6 +19,8 @@ export const totalRecords = 'totalRecords'
 export const successfulRecords = 'successfulRecords'
 export const currentPageNumber = 1
 export const polygonFaucet = 'https://faucet.polygon.technology/'
+export const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export const apiStatusCodes = {
   API_STATUS_SUCCESS: 200,

--- a/nextjs/src/features/schemas/components/SchemaCard.tsx
+++ b/nextjs/src/features/schemas/components/SchemaCard.tsx
@@ -108,7 +108,9 @@ const SchemaCard = (props: ISchemaCardProps): React.JSX.Element => {
     }
 
     if (!props.w3cSchema && !hasNestedAttributes && props.schemaId) {
-      router.push(`/organizations/schemas/${props.schemaId}`)
+      router.push(
+        `/organizations/schemas/${props.schemaId}?alias=${props.schemaName}`,
+      )
     }
 
     if (props.onClickCallback) {


### PR DESCRIPTION
# What 

Changed the bread crumb id's to its relevant name
<img width="1916" height="498" alt="image" src="https://github.com/user-attachments/assets/61326598-2f02-4ec3-92be-f102eea7715a" />
changed it as discussed in meeting to replace organization with overview
<img width="1916" height="498" alt="image" src="https://github.com/user-attachments/assets/869065b0-32f3-40d8-bb80-ee24fcde1ca3" />
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaced breadcrumb UUIDs with 'Overview' and added copy-to-clipboard in `breadcrumbs.tsx`, updated navigation in `OrganizationDashboard.tsx`, and appended alias to schema URLs in `SchemaCard.tsx`.
> 
>   - **Breadcrumbs**:
>     - Replace organization UUIDs with 'Overview' in `breadcrumbs.tsx`.
>     - Add copy-to-clipboard functionality for breadcrumb items.
>   - **Constants**:
>     - Add `UUID_REGEX` to `CommonConstant.ts` for UUID validation.
>   - **Organization Dashboard**:
>     - Use `useTransition` for smoother navigation in `OrganizationDashboard.tsx`.
>   - **Schema Card**:
>     - Append `alias` to schema URL in `SchemaCard.tsx` for better identification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for f78a41620e44958e2d9d81f12f1d15ab640653cc. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->