### PR TITLE
Fixed text overflow on user's modal in invitation section

### DIFF
--- a/nextjs/src/features/invitations/components/sendInvitations.tsx
+++ b/nextjs/src/features/invitations/components/sendInvitations.tsx
@@ -15,6 +15,12 @@ import {
   RoleI,
   SendInvitationModalProps,
 } from '../interfaces/invitation-interface'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 import { AlertComponent } from '@/components/AlertComponent'
 import { AxiosResponse } from 'axios'
@@ -238,7 +244,19 @@ export default function SendInvitationModal({
                       <MailIcon className="text-muted-foreground h-9 w-9" />
                     </div>
                     <div>
-                      <p className="font-medium">{invitation.email}</p>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <p className="font-medium">
+                              {invitation.email.slice(0, 30)}
+                              {invitation.email.length > 29 && ' . . .'}
+                            </p>
+                          </TooltipTrigger>
+                          <TooltipContent side="top">
+                            {invitation.email}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                       <p className="text-muted-foreground text-sm">
                         Role: Member
                       </p>

--- a/nextjs/src/features/users/components/EditUserRoleModal.tsx
+++ b/nextjs/src/features/users/components/EditUserRoleModal.tsx
@@ -12,6 +12,12 @@ import {
 import React, { useEffect, useState } from 'react'
 import { RoleNames, apiStatusCodes } from '@/config/CommonConstant'
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
   editOrganizationUserRole,
   getOrganizationRoles,
 } from '@/app/api/organization'
@@ -179,9 +185,33 @@ const EditUserRoleModal = ({
               <div className="mb-2 flex items-center pb-4">
                 <div className="flex-grow">
                   <p className="truncate text-base font-semibold">
-                    {user?.firstName} {user?.lastName}
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="font-medium">
+                            {`${user?.firstName ?? ''} ${user?.lastName ?? ''}`.slice(
+                              0,
+                              30,
+                            )}
+                            {`${user?.firstName ?? ''} ${user?.lastName ?? ''}`
+                              .length > 29 && ' . . .'}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top">{`${user?.firstName ?? ''} ${user?.lastName ?? ''}`}</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                   </p>
-                  <span className="text-sm">{user?.email}</span>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="text-sm">
+                          {(user?.email ?? '').slice(0, 30)}
+                          {user?.email.length > 29 && ' . . .'}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">{user?.email}</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>{' '}
                 </div>
               </div>
 

--- a/nextjs/src/features/users/components/TabData.tsx
+++ b/nextjs/src/features/users/components/TabData.tsx
@@ -1,6 +1,12 @@
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import React, { JSX, useCallback } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -189,7 +195,19 @@ function TabData({
                     </Avatar>
                     <div>
                       <h3 className="text-base font-semibold">
-                        {invitation.email}
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <p className="font-medium">
+                                {invitation.email.slice(0, 30)}
+                                {invitation.email.length > 29 && ' . . .'}
+                              </p>
+                            </TooltipTrigger>
+                            <TooltipContent side="top">
+                              {invitation.email}
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       </h3>
                       <div className="flex-grow text-start">
                         <DateTooltip date={invitation.createDateTime}>


### PR DESCRIPTION
# What

Fixed text overflow on user's modal in invitation section
<img width="1920" height="964" alt="Pasted image" src="https://github.com/user-attachments/assets/c78b6052-a376-4aef-95e8-d16a710676a9" />
<img width="1920" height="964" alt="Pasted image (2)" src="https://github.com/user-attachments/assets/83699dfb-1035-4e3b-9234-6853910e3938" />
<img width="1920" height="964" alt="Pasted image (3)" src="https://github.com/user-attachments/assets/3d21a270-cc2e-4e0c-b72e-704007115d32" />
