### PR TITLE
Added credential list drawer and their label for display on credentials table

### DIFF
--- a/nextjs/src/features/organization/connectionIssuance/components/Credentials.tsx
+++ b/nextjs/src/features/organization/connectionIssuance/components/Credentials.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import {
-  ConnectionIdCell,
   DateCell,
   SchemaNameCell,
   StatusCellForCredential,
@@ -21,11 +20,13 @@ import { ConnectionApiSortFields } from '@/features/connections/types/connection
 import { DataTable } from '../../../../components/ui/generic-table-component/data-table'
 import { DidMethod } from '@/features/common/enum'
 import { Features } from '@/common/enums'
+import { ISidebarSliderData } from '@/features/schemas/type/schemas-interface'
 import { IssuedCredential } from '../type/Issuance'
 import Loader from '@/components/Loader'
 import PageContainer from '@/components/layout/page-container'
 import { RefreshCw } from 'lucide-react'
 import RoleViewButton from '@/components/RoleViewButton'
+import SidePanelComponent from '@/config/SidePanelCommon'
 import { apiStatusCodes } from '@/config/CommonConstant'
 import { getIssuedCredentials } from '@/app/api/Issuance'
 import { getOrganizationById } from '@/app/api/organization'
@@ -53,6 +54,8 @@ const Credentials = (): JSX.Element => {
   const [isW3C, setIsW3C] = useState(false)
   const [reloading, setReloading] = useState<boolean>(false)
   const [isIssuing, setIsIssuing] = useState(false)
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const [fields, setSelectedFields] = useState<ISidebarSliderData[]>([])
 
   // Consolidated pagination state
   const [pagination, setPagination] = useState<PaginationState>({
@@ -173,23 +176,6 @@ const Credentials = (): JSX.Element => {
 
   const columnData: IColumnData[] = [
     {
-      id: 'credentialExchangeId',
-      title: 'credential Exchange Id',
-      accessorKey: 'credentialExchangeId',
-      columnFunction: [
-        'hide',
-        {
-          sortCallBack: async (order): Promise<void> => {
-            setPagination((prev) => ({
-              ...prev,
-              sortBy: 'credentialExchangeId',
-              sortOrder: order,
-            }))
-          },
-        },
-      ],
-    },
-    {
       id: 'connectionId',
       title: 'Issued to',
       accessorKey: 'connectionId',
@@ -205,7 +191,36 @@ const Credentials = (): JSX.Element => {
         },
       ],
       cell: ({ row }) => (
-        <ConnectionIdCell connectionId={row.original.connectionId} />
+        <button
+          className="url-link"
+          onClick={() => {
+            setSelectedFields(() => {
+              const data = [
+                {
+                  label: 'Credential Exchange Id',
+                  value: row.original.credentialExchangeId,
+                  copyable: true,
+                },
+                {
+                  label: 'Schema Id',
+                  value: row.original.schemaId,
+                  copyable: true,
+                },
+                {
+                  label: 'Connection Id',
+                  value: row.original.connectionId ?? 'Not Available',
+                  copyable: true,
+                },
+              ]
+              return data
+            })
+            setIsDrawerOpen(true)
+          }}
+        >
+          {row.original.connections
+            ? row.original.connections.theirLabel
+            : 'Not Available'}
+        </button>
       ),
     },
     {
@@ -345,6 +360,11 @@ const Credentials = (): JSX.Element => {
           }
         />
       </div>
+      <SidePanelComponent
+        open={isDrawerOpen}
+        onOpenChange={setIsDrawerOpen}
+        fields={fields}
+      />
     </PageContainer>
   )
 }


### PR DESCRIPTION
# What 

Added credential list drawer and their label for display on credentials table
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c0b1c725-1c2b-4201-b892-42f780c9f1a2" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a drawer to `Credentials.tsx` to display credential details with a button-triggered side panel.
> 
>   - **Behavior**:
>     - Adds a drawer to `Credentials.tsx` to display credential details when a button is clicked.
>     - Displays `Credential Exchange Id`, `Schema Id`, and `Connection Id` in the drawer, with copyable options.
>   - **Components**:
>     - Adds `SidePanelComponent` to `Credentials.tsx` to manage the drawer state and display fields.
>     - Removes `ConnectionIdCell` import and usage in `Credentials.tsx`.
>   - **UI**:
>     - Replaces `ConnectionIdCell` with a button that opens the drawer in `Credentials.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 06ea7ae2df6153ca8f7e91527bb1a052359ddda2. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->