### PR TITLE
chore: ability to add remediation commit

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+allowRemediationCommits:
+  individual: true
+  thirdParty: true


### PR DESCRIPTION
Ability to add remediation commits as per: https://github.com/cncf/dco2?tab=readme-ov-file#remediation-commits
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `.github/dco.yml` to enable remediation commits for individual and third-party contributions.
> 
>   - **Configuration**:
>     - Adds `.github/dco.yml` to enable remediation commits.
>     - Sets `allowRemediationCommits` for `individual` and `thirdParty` to `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 42aefc0f0fd33b7b250062c4c628b2ab02c2ed6e. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->