### PR TITLE
Prevent slider window crash when clicking "Not Available" credential ID in table

### DIFF
--- a/nextjs/src/features/organization/connectionIssuance/components/Credentials.tsx
+++ b/nextjs/src/features/organization/connectionIssuance/components/Credentials.tsx
@@ -206,15 +206,16 @@ const Credentials = (): JSX.Element => {
                 },
                 {
                   label: 'Issued To',
-                  value: row.original.connections.theirLabel ?? 'Not Available',
+                  value:
+                    row.original.connections?.theirLabel || 'Not Available',
                 },
                 {
                   label: 'Schema Name',
-                  value: row.original.schemaName ?? 'Not Available',
+                  value: row.original.schemaName || 'Not Available',
                 },
                 {
                   label: 'Schema Id',
-                  value: row.original.schemaId ?? 'Not Available',
+                  value: row.original.schemaId || 'Not Available',
                   copyable: true,
                 },
                 {
@@ -233,7 +234,7 @@ const Credentials = (): JSX.Element => {
                 },
                 {
                   label: 'Connection Id',
-                  value: row.original.connectionId ?? 'Not Available',
+                  value: row.original.connectionId || 'Not Available',
                   copyable: true,
                 },
               ]


### PR DESCRIPTION
# What 

- fixed the crashing of slider window when clicking on the not available id in credential table
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes crash in `Credentials` component by using `||` for default values in several fields.
> 
>   - **Behavior**:
>     - Fixes crash in `Credentials` component when clicking 'Not Available' credential ID.
>     - Uses `||` instead of `??` for default values in `Issued To`, `Schema Name`, `Schema Id`, and `Connection Id` fields.
>   - **Files**:
>     - Changes in `Credentials.tsx` to handle 'Not Available' cases properly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 3fa272f6e1c1b6f76b49f9b3adbfab8da865b3a9. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->