### PR TITLE
Fixed Bulk issuance schema filter resetting to previous value on change

### DIFF
--- a/src/features/organization/bulkIssuance/components/BulkIssuance.tsx
+++ b/src/features/organization/bulkIssuance/components/BulkIssuance.tsx
@@ -41,6 +41,7 @@ import Steps from './Steps'
 import Table from './Table'
 import { getCsvFileData } from '@/app/api/BulkIssuance'
 import { pathRoutes } from '@/config/pathRoutes'
+import { resetSchemaDetails } from '@/lib/schemaStorageSlice'
 import { setAllSchema } from '@/lib/storageKeys'
 import { useRouter } from 'next/navigation'
 
@@ -197,6 +198,7 @@ const BulkIssuance = (): JSX.Element => {
   const allow = useRef<boolean>(true) // Reset to allow notification; prevents duplicate notifications on select
 
   const handleSelect = (value: Option): void => {
+    dispatch(resetSchemaDetails())
     const safeValue = {
       ...value,
       schemaIdentifier: value?.schemaIdentifier ?? '',
@@ -306,6 +308,7 @@ const BulkIssuance = (): JSX.Element => {
   const handleFilterChange = async (value: string): Promise<void> => {
     const isAllSchemas = value === 'All schemas'
     handleReset(context)
+    dispatch(resetSchemaDetails())
     setClear((prev) => !prev)
     setIsAllSchema(isAllSchemas)
     dispatch(setAllSchema(isAllSchemas))

--- a/src/features/organization/connectionIssuance/components/Issuance.tsx
+++ b/src/features/organization/connectionIssuance/components/Issuance.tsx
@@ -46,6 +46,7 @@ import SummaryCardW3c from '@/components/SummaryCardW3c'
 import { getOrganizationById } from '@/app/api/organization'
 import { getSchemaCredDef } from '@/app/api/schema'
 import { pathRoutes } from '@/config/pathRoutes'
+import { resetSchemaDetails } from '@/lib/schemaStorageSlice'
 import { setAllSchema } from '@/lib/storageKeys'
 import { useRouter } from 'next/navigation'
 import { useSelector } from 'react-redux'
@@ -331,6 +332,7 @@ const IssueCred = (): React.JSX.Element => {
   }
 
   const handleFilterChange = async (value: string): Promise<void> => {
+    dispatch(resetSchemaDetails())
     const isAllSchemas = value === 'All schemas'
     dispatch(setAllSchema(isAllSchemas))
   }
@@ -367,14 +369,15 @@ const IssueCred = (): React.JSX.Element => {
                   className="border-muted max-w-lg border-1"
                   options={credentialOptions}
                   value={selectValue}
-                  onValueChange={(value) =>
+                  onValueChange={(value) => {
+                    dispatch(resetSchemaDetails())
                     handleSelect({
                       value,
                       setSchemaDetails,
                       allSchema,
                       w3cSchema,
                     })
-                  }
+                  }}
                   onSearchChange={handleSearchChange}
                   enableInternalSearch={!(w3cSchema && allSchema)}
                   placeholder={

--- a/src/features/organization/emailIssuance/components/EmailIssuance.tsx
+++ b/src/features/organization/emailIssuance/components/EmailIssuance.tsx
@@ -45,6 +45,7 @@ import { RootState } from '@/lib/store'
 import { SelectRef } from '../../bulkIssuance/components/BulkIssuance'
 import { itemPerPage } from '@/config/CommonConstant'
 import { pathRoutes } from '@/config/pathRoutes'
+import { resetSchemaDetails } from '@/lib/schemaStorageSlice'
 import { setAllSchema } from '@/lib/storageKeys'
 import { useRouter } from 'next/navigation'
 
@@ -218,6 +219,7 @@ const EmailIssuance = (): JSX.Element => {
       schemaVersion: value.schemaVersion ?? '',
       schemaIdentifier: value.schemaIdentifier ?? '',
     }
+    dispatch(resetSchemaDetails())
     handleSelectChange(fullValue)
   }
 
@@ -226,6 +228,7 @@ const EmailIssuance = (): JSX.Element => {
   }
 
   const handleFilterChange = async (value: string): Promise<void> => {
+    dispatch(resetSchemaDetails())
     const isAllSchemas = value === 'All schemas'
     dispatch(setAllSchema(isAllSchemas))
   }


### PR DESCRIPTION
# What

- Fix the bulk issuance Schema filter issue where on change of filter it used to fetch back the previous value due to slice data
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes schema filter reset issue in bulk issuance by dispatching `resetSchemaDetails()` on filter change in relevant components.
> 
>   - **Behavior**:
>     - Fixes schema filter reset issue in `BulkIssuance.tsx`, `Issuance.tsx`, and `EmailIssuance.tsx` by dispatching `resetSchemaDetails()` on filter change.
>     - Ensures schema details are reset when changing schema filters to prevent reverting to previous values.
>   - **Functions**:
>     - Adds `dispatch(resetSchemaDetails())` in `handleSelect`, `handleFilterChange`, and `onValueChange` functions in the affected files.
>   - **Misc**:
>     - Imports `resetSchemaDetails` from `schemaStorageSlice` in the affected files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for 5eac64c5fff68fc7b0fad272d2f593880a67166c. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->