### PR TITLE
fix: mark client side variable as server side to add security for sensitive env keys

### DIFF
--- a/src/app/actions/passwordActions.ts
+++ b/src/app/actions/passwordActions.ts
@@ -1,0 +1,51 @@
+'use server'
+
+import {
+  IEncryptPasswordForSignIn,
+  IEncryptPasswordResponse,
+} from '@/common/interface'
+
+import CryptoJS from 'crypto-js'
+
+export const encryptPasswordActionForSignIn = async (
+  password: string,
+  email: string,
+  isPassword: boolean,
+): Promise<IEncryptPasswordForSignIn> => {
+  const { CRYPTO_PRIVATE_KEY } = process.env
+
+  if (!CRYPTO_PRIVATE_KEY) {
+    throw new Error('CRYPTO_PRIVATE_KEY is missing!')
+  }
+
+  const encryptedPassword = CryptoJS.AES.encrypt(
+    JSON.stringify(password),
+    CRYPTO_PRIVATE_KEY,
+  ).toString()
+
+  return {
+    password: encryptedPassword,
+    email,
+    isPassword,
+  }
+}
+
+export const encryptPasswordAction = async (
+  password: string,
+): Promise<IEncryptPasswordResponse> => {
+  const { CRYPTO_PRIVATE_KEY } = process.env
+
+  if (!CRYPTO_PRIVATE_KEY) {
+    throw new Error('CRYPTO_PRIVATE_KEY is missing!')
+  }
+
+  // Encrypt the password on the server
+  const encryptedPassword = CryptoJS.AES.encrypt(
+    JSON.stringify(password),
+    CRYPTO_PRIVATE_KEY,
+  ).toString()
+
+  return {
+    password: encryptedPassword,
+  }
+}

--- a/src/app/api/Auth.ts
+++ b/src/app/api/Auth.ts
@@ -7,7 +7,9 @@ import {
 
 import { AxiosResponse } from 'axios'
 import CryptoJS from 'crypto-js'
+import { IEncryptPasswordForSignIn } from '@/common/interface'
 import { apiRoutes } from '@/config/apiRoutes'
+import { encryptPasswordActionForSignIn } from '@/app/actions/passwordActions'
 import { getHeaderConfigs } from '@/config/GetHeaderConfigs'
 
 export interface IUserSignUpData {
@@ -222,11 +224,17 @@ export const addPasswordDetails = async (
   }
 }
 
+export const passwordEncryptionForSignIn = async (
+  password: string,
+  email: string,
+  isPassword: boolean,
+): Promise<IEncryptPasswordForSignIn> =>
+  encryptPasswordActionForSignIn(password, email, isPassword)
+
 export const passwordEncryption = (password: string): string => {
-  const CRYPTO_PRIVATE_KEY: string | undefined =
-    process.env.NEXT_PUBLIC_CRYPTO_PRIVATE_KEY
+  const { CRYPTO_PRIVATE_KEY } = process.env
   if (!CRYPTO_PRIVATE_KEY) {
-    throw new Error('Missing NEXT_PUBLIC_CRYPTO_PRIVATE_KEY')
+    throw new Error('Missing CRYPTO_PRIVATE_KEY')
   }
   const encryptedPassword: string = CryptoJS.AES.encrypt(
     JSON.stringify(password),

--- a/src/common/interface.ts
+++ b/src/common/interface.ts
@@ -26,3 +26,13 @@ export interface IAlertComponent {
   path?: string
   onAlertClose: () => void
 }
+
+export interface IEncryptPasswordForSignIn {
+  password: string
+  email: string
+  isPassword: boolean
+}
+
+export interface IEncryptPasswordResponse {
+  password: string
+}

--- a/src/features/components/SessionManager.tsx
+++ b/src/features/components/SessionManager.tsx
@@ -4,8 +4,8 @@ import { setRefreshToken, setSessionId, setToken } from '@/lib/authSlice'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 import { apiRoutes } from '@/config/apiRoutes'
+import { encryptPasswordAction } from '@/app/actions/passwordActions'
 import { envConfig } from '@/config/envConfig'
-import { passwordEncryption } from '@/app/api/Auth'
 import { useAppDispatch } from '@/lib/hooks'
 import { useEffect } from 'react'
 import { useSession } from 'next-auth/react'
@@ -84,8 +84,8 @@ export const SessionManager = ({
     redirectTo: string | null,
   ): Promise<void> => {
     try {
-      const encrypted = passwordEncryption(sessionId)
-      const encoded = encodeURIComponent(encrypted)
+      const encrypted = await encryptPasswordAction(sessionId)
+      const encoded = encodeURIComponent(encrypted.password)
       const resp = await fetch(
         `${envConfig.NEXT_PUBLIC_BASE_URL}${apiRoutes.auth.fetchSessionDetails}?sessionId=${encoded}`,
         {

--- a/src/features/components/user-auth-form.tsx
+++ b/src/features/components/user-auth-form.tsx
@@ -15,7 +15,7 @@ import React, { useState } from 'react'
 import {
   forgotPassword,
   getUserProfile,
-  passwordEncryption,
+  passwordEncryptionForSignIn,
 } from '@/app/api/Auth'
 import { useRouter, useSearchParams } from 'next/navigation'
 
@@ -84,11 +84,11 @@ export default function SignInViewPage(): React.JSX.Element {
   }): Promise<void> => {
     try {
       setLoading(true)
-      const entityData = {
-        email: values.email,
-        password: passwordEncryption(values.password || ''),
-        isPassword: isPasswordTab,
-      }
+      const entityData = await passwordEncryptionForSignIn(
+        values.password || '',
+        values.email,
+        isPasswordTab,
+      )
 
       const response = await signIn('credentials', {
         ...entityData,

--- a/src/features/profile/components/Billing.tsx
+++ b/src/features/profile/components/Billing.tsx
@@ -25,7 +25,7 @@ export default function Billing(): JSX.Element {
     },
     {
       name: 'PRO',
-      link: `${sovioLandingPageURL}/billing`,
+      link: `${sovioLandingPageURL}/pricing`,
       buttonLabel: 'Contact Us',
       features: [
         'Organizations: Unlimited',

--- a/src/features/verification/components/SchemaListUtils.ts
+++ b/src/features/verification/components/SchemaListUtils.ts
@@ -87,7 +87,7 @@ export const decryptValue = (value: string): string => {
   try {
     const returnValue = CryptoJS.AES.decrypt(
       value,
-      `${process.env.NEXT_PUBLIC_CRYPTO_PRIVATE_KEY}`,
+      `${process.env.CRYPTO_PRIVATE_KEY}`,
     )
     const decryptedString = returnValue.toString(CryptoJS.enc.Utf8)
     return decryptedString


### PR DESCRIPTION
### What

- fix: mark client side variable as server side to add sercurity for sensitive env keys
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance security by marking sensitive environment keys as server-side and refactor password encryption logic.
> 
>   - **Security Enhancements**:
>     - Marked `CRYPTO_PRIVATE_KEY` as server-side only in `passwordActions.ts` and `Auth.ts` to prevent exposure of sensitive keys.
>     - Updated `decryptValue()` in `SchemaListUtils.ts` to use server-side `CRYPTO_PRIVATE_KEY`.
>   - **Password Encryption**:
>     - Moved password encryption logic to `encryptPasswordActionForSignIn` and `encryptPasswordAction` in `passwordActions.ts`.
>     - Replaced `passwordEncryption` with `encryptPasswordAction` in `SessionManager.tsx`.
>     - Replaced `passwordEncryption` with `passwordEncryptionForSignIn` in `user-auth-form.tsx`.
>   - **Miscellaneous**:
>     - Changed link from `/billing` to `/pricing` in `Billing.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=credebl%2Fstudio&utm_source=github&utm_medium=referral)<sup> for dce3d5eb89089cffe21a2370b5bb288ca9625350. You can [customize](https://app.ellipsis.dev/credebl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->